### PR TITLE
Private Chat Room Feature

### DIFF
--- a/DndChat/Controllers/RoomsController.cs
+++ b/DndChat/Controllers/RoomsController.cs
@@ -1,0 +1,142 @@
+﻿using DndChat.Services;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using System.Security.Claims;
+using DndChat.Models;
+using DndChat.Data;
+using Microsoft.AspNetCore.Identity;
+using DndChat.Hubs;
+using Microsoft.AspNetCore.SignalR;
+
+namespace DndChat.Controllers
+{
+    [Authorize]
+    public class RoomsController : Controller
+    {
+        // DI: room service (create/join/lookup)
+        private readonly IChatRoomService _chatRooms;
+        // DI: identity helper to read current user's ID safely
+        private readonly UserManager<ChatUser> _users;
+
+        //To broadcast that a room was deleted
+        private readonly IHubContext<ChatHub> _hub;
+
+        public RoomsController(IChatRoomService chatRooms,
+                               UserManager<ChatUser> users,
+                               IHubContext<ChatHub> hub)
+        {
+            _chatRooms = chatRooms;
+            _users = users;
+            _hub = hub;
+        }
+        // A simple screen with two cards: Join or Create.
+        public async Task<IActionResult> Index()
+        {
+            var userId = _users.GetUserId(User);
+            if (string.IsNullOrEmpty(userId)) return Unauthorized();
+
+            var myRooms = await _chatRooms.RoomsForUserListAsync(userId);
+            return View(myRooms);
+        }
+
+        // Creates a room with the given name and redirects to /Rooms/Room/{id}
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> Create(string? roomName)
+        {
+            // Get the current signed-in user's ID (Identity's User.Id).
+            // This wraps the NameIdentifier claim and returns null if missing.
+            var userId = _users.GetUserId(User);
+            if (string.IsNullOrEmpty(userId))
+                return Unauthorized();
+
+            // Ask the service to create a private room owned by this user.
+            // It returns a tuple (roomId, joinCode). We only need roomId here,
+            // so discard the second value with "_".
+            var (roomId, _) = await _chatRooms.CreatePrivateAsync(userId, roomName);
+
+            // Redirect to the dedicated room page action "Room".
+            // nameof(Room) is refactor-safe (compiler-checked) vs a raw "Room" string.
+            return RedirectToAction(nameof(Room), new { id = roomId });
+
+        }
+        // Looks up a room by the code the user typed and redirects to it.
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> Join(string joinCode)
+        {
+            var userId = _users.GetUserId(User);
+            if (string.IsNullOrEmpty(userId))
+                return Unauthorized();
+
+            // Resolve code -> room id
+            var roomId = await _chatRooms.ResolveByJoinCodeAsync(joinCode);
+            if (roomId is null)
+            {
+                TempData["JoinError"] = "Invalid code. Double check and try again.";
+                return RedirectToAction(nameof(Index));
+            }
+
+            // Ensure this user is a member BEFORE showing the room page
+            await _chatRooms.AddMemberAsync(userId, roomId);
+
+            return RedirectToAction(nameof(Room), new { id = roomId });
+        }
+        // Optional: leave a room (HTTP version; your hub also has LeaveRoom for SignalR group only)
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> Leave(string id)
+        {
+            var userId = _users.GetUserId(User);
+            if (string.IsNullOrEmpty(userId)) return Unauthorized();
+
+            await _chatRooms.RemoveMemberAsync(userId, id);
+            TempData["JoinError"] = "You left the room."; // small confirmation
+            return RedirectToAction(nameof(Index));
+        }
+        // GET /Rooms/Room/{id}
+        // Renders the room page; the page's JS will connect to the hub and call JoinByCode(id).
+        [HttpGet("/Rooms/Room/{id}")]
+        public async Task<IActionResult> Room(string id)
+        {
+            var userId = _users.GetUserId(User);
+            if (string.IsNullOrEmpty(userId)) return Unauthorized();
+
+            var header = await _chatRooms.GetRoomHeaderForUserAsync(userId, id);
+            if (header is null)
+            {
+                TempData["JoinError"] = "You don’t have access to that room. Enter the code to join.";
+                return RedirectToAction(nameof(Index));
+            }
+
+            ViewData["RoomId"] = header.Id;
+            ViewData["RoomName"] = header.Name;
+            ViewData["JoinCode"] = header.JoinCode;
+            ViewData["IsOwner"] = header.IsOwner;
+
+            return View();
+        }
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> Delete(string id)
+        {
+            var userId = _users.GetUserId(User);
+            if (string.IsNullOrEmpty(userId)) return Unauthorized();
+
+            var ok = await _chatRooms.DeleteRoomAsync(userId, id);
+            if (ok)
+            {
+                // Tell anyone currently in that SignalR group that the room is gone
+                await _hub.Clients.Group(id).SendAsync("RoomDeleted", id, "This room was deleted by the owner.");
+                TempData["JoinError"] = "Room deleted.";
+            }
+            else
+            {
+                TempData["JoinError"] = "You don’t have permission to delete that room (or it no longer exists).";
+            }
+
+            return RedirectToAction(nameof(Index));
+        }
+
+    }
+}

--- a/DndChat/Data/ApplicationDbContext.cs
+++ b/DndChat/Data/ApplicationDbContext.cs
@@ -7,8 +7,45 @@ namespace DndChat.Data
     public class ApplicationDbContext : IdentityDbContext<ChatUser>
     {
         public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options)
-            : base(options)
+            : base(options) {}
+        
+        public DbSet<ChatRoom> ChatRooms => Set<ChatRoom>();
+        public DbSet<ChatMembership> ChatMemberships => Set<ChatMembership>();
+        public DbSet<ChatMessage> ChatMessages => Set<ChatMessage>();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
+            base.OnModelCreating(modelBuilder);
+
+            // ChatRoom: ensure join codes are unique and reasonably sized.
+            modelBuilder.Entity<ChatRoom>(entity =>
+            {
+                entity.HasIndex(room => room.JoinCode).IsUnique();
+                entity.Property(room => room.JoinCode).HasMaxLength(64);
+            });
+
+            // ChatMembership: prevent duplicate memberships per (room, user) and set relationship to ChatRoom.
+            modelBuilder.Entity<ChatMembership>(entity =>
+            {
+                entity.HasIndex(membership => new { membership.ChatRoomId, membership.UserId }).IsUnique();
+
+                entity.HasOne(membership => membership.ChatRoom)
+                    .WithMany(room => room.Members)
+                    .HasForeignKey(membership => membership.ChatRoomId)
+                    .OnDelete(DeleteBehavior.Cascade);
+            });
+
+            // ChatMessage: link each message to its room and cap message length.
+            modelBuilder.Entity<ChatMessage>(entity =>
+            {
+                entity.HasOne(message => message.ChatRoom)
+                    .WithMany(room => room.Messages)
+                    .HasForeignKey(message => message.ChatRoomId)
+                    .OnDelete(DeleteBehavior.Cascade);
+
+                entity.Property(message => message.MessageText).HasMaxLength(2000);
+            });
         }
+
     }
 }

--- a/DndChat/Hubs/ChatHub.cs
+++ b/DndChat/Hubs/ChatHub.cs
@@ -1,59 +1,165 @@
-﻿using Microsoft.AspNetCore.Authentication.JwtBearer;
+﻿using DndChat.Services;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.SignalR;
 
 namespace DndChat.Hubs
 {
-    // This attribute enforces authentication and explicitly lists the two allowed schemes.
-    // Identity AND JWT bearer tokens.
+    // Only authenticated users may connect (via cookie or JWT).
     [Authorize(AuthenticationSchemes = "Bearer,Identity.Application")]
     public class ChatHub : Hub
     {
-        // TEMP a constant group name for your global chat
-        // When private chats are added, switch to database-driven groups
-        public const string GlobalGroup = "global";
-        // logging so we can see connects/disconnects in the console
-        private readonly ILogger<ChatHub> _log;
-        public ChatHub(ILogger<ChatHub> log) => _log = log;
+        // DI: persistence + helpers for rooms/members/messages
+        private readonly IChatRoomService _chatRoomService;
 
-        // This runs when a client completes the SignalR handshake.
-        // Context.User is the authenticated principal built from the cookie or JWT.
+        // Constant name for the SignalR "global" group
+        public const string GlobalGroup = "global";
+
+        // DI: server-side logging so we see connects/disconnects/errors
+        private readonly ILogger<ChatHub> _log;
+
+        public ChatHub(ILogger<ChatHub> log, IChatRoomService chatRoomService)
+        {
+            _log = log;
+            _chatRoomService = chatRoomService;
+        }
+
+        // Runs when the SignalR handshake completes.
+        // We keep this minimal on purpose: just log the event.
+        // The PAGE (global or private room) will explicitly join what it needs.
         public override async Task OnConnectedAsync()
         {
-            // Get the authenticated username (from ClaimTypes.Name)
             var userName = Context.User?.Identity?.Name ?? "unknown";
-            // Log it for information purposes
             _log.LogInformation("SR connected: {User} ({Conn})", userName, Context.ConnectionId);
-            // Add everyone to the global group
-            await Groups.AddToGroupAsync(Context.ConnectionId, GlobalGroup);
-            // Send a notice to everyone in the group that someone joined
-            await Clients.Group(GlobalGroup).SendAsync("SystemNotice", GlobalGroup, $"{userName} joined chat");
-
             await base.OnConnectedAsync();
         }
 
+        // Runs when the connection is closed.
+        // Also minimal: we just log. We don't broadcast "left chat" here
+        // because this connection might have been in a private room only.
         public override async Task OnDisconnectedAsync(Exception? ex)
         {
-            
             var userName = Context.User?.Identity?.Name ?? "unknown";
-
             _log.LogInformation(ex, "SR disconnected: {User} ({Conn})", userName, Context.ConnectionId);
-
-            await Clients.Group(GlobalGroup).SendAsync("SystemNotice", GlobalGroup, $"{userName} left chat");
-
             await base.OnDisconnectedAsync(ex);
         }
-        // This is a hub method clients can call.
-        // It reads the authenticated user's name from Context.User and broadcasts to everyone.
+
+        // === GLOBAL CHAT ===
+
+        // Called by the Global page JS AFTER it starts the connection.
+        // - Adds THIS connection to the "global" SignalR group so it receives global messages.
+        // - Emits a system notice so others in global see that the user joined.
+        public async Task JoinGlobal()
+        {
+            var userName = Context.User?.Identity?.Name ?? "unknown";
+
+            await Groups.AddToGroupAsync(Context.ConnectionId, GlobalGroup);
+
+            await Clients.Group(GlobalGroup)
+                .SendAsync("SystemNotice", GlobalGroup, $"{userName} joined chat");
+        }
+
+        // Optional helper if you ever add a "Leave global" button on the page.
+        // (Does NOT remove cookie/JWT auth—this only leaves the SignalR group.)
+        public Task LeaveGlobal()
+            => Groups.RemoveFromGroupAsync(Context.ConnectionId, GlobalGroup);
+
+        // Sends a message to the global room and (optionally) saves it to DB
+        // under the "global" ChatRoom (you seeded this in Program.cs).
         public async Task SendMessage(string message)
         {
-            // Authenticated username (comes from ClaimTypes.Name)
+            var userId = Context.UserIdentifier ?? "unknown-id";
             var userName = Context.User?.Identity?.Name ?? "unknown";
+
             if (string.IsNullOrWhiteSpace(message))
                 throw new HubException("Message cannot be empty.");
-            _log.LogInformation("Chat: {User} -> {Msg}", userName, message);
+
+            if (message.Length > 1000)
+                throw new HubException("Message too long.");
+
+            // Persist to DB so global history exists (because you chose Pattern B).
+            await _chatRoomService.SaveMessageAsync("global", userId, userName, message);
+
+            // Broadcast to everyone currently in the global SignalR group.
             await Clients.Group(GlobalGroup).SendAsync("ReceiveMessage", userName, message.Trim());
+        }
+
+        // === PRIVATE ROOMS (unchanged from your MVP) ===
+        // Create, join, send, leave. The private room page calls these explicitly.
+
+        // Creates a private room, adds THIS connection to its SignalR group,
+        // and returns the join code the user can share with friends.
+        public async Task<(string roomId, string joinCode)> CreatePrivateRoom(string? roomName = null)
+        {
+            var userId = Context.UserIdentifier ?? throw new HubException("Not authenticated.");
+            var userName = Context.User?.Identity?.Name ?? userId;
+
+            var (roomId, joinCode) = await _chatRoomService.CreatePrivateAsync(userId, roomName);
+
+            await Groups.AddToGroupAsync(Context.ConnectionId, roomId);
+
+            await Clients.Group(roomId)
+                .SendAsync("SystemNotice", roomId, $"{userName} created the room");
+
+            // MVP: joinCode == roomId
+            return (roomId, joinCode);
+        }
+
+        // Joins a room by its code (same as room id in MVP),
+        // ensures membership is saved, sends recent history to the caller,
+        // and notifies the room.
+        public async Task JoinByCode(string joinCode)
+        {
+            var userId = Context.UserIdentifier ?? throw new HubException("Not authenticated.");
+            var userName = Context.User?.Identity?.Name ?? userId;
+
+            var roomId = await _chatRoomService.ResolveByJoinCodeAsync(joinCode)
+                         ?? throw new HubException("Invalid code.");
+
+            if (!await _chatRoomService.IsMemberAsync(userId, roomId))
+                await _chatRoomService.AddMemberAsync(userId, roomId);
+
+            await Groups.AddToGroupAsync(Context.ConnectionId, roomId);
+
+            // Load recent history as DTOs so the client gets { UserName, Text, SentUtc }
+            var recentDtos = await _chatRoomService.LastMessagesDtoAsync(roomId, 50);
+            await Clients.Caller.SendAsync("LoadHistory", roomId, recentDtos);
+
+            await Clients.Group(roomId)
+                .SendAsync("SystemNotice", roomId, $"{userName} joined");
+        }
+
+        // Sends a message to a specific private room after validating membership.
+        public async Task SendRoomMessage(string roomId, string message)
+        {
+            var userId = Context.UserIdentifier ?? throw new HubException("Not authenticated.");
+            var userName = Context.User?.Identity?.Name ?? userId;
+
+            if (string.IsNullOrWhiteSpace(roomId))
+                throw new HubException("Room id required.");
+            if (string.IsNullOrWhiteSpace(message))
+                throw new HubException("Message cannot be empty.");
+
+            var isMember = await _chatRoomService.IsMemberAsync(userId, roomId);
+            if (!isMember) throw new HubException("Not a member.");
+
+            await _chatRoomService.SaveMessageAsync(roomId, userId, userName, message);
+
+            await Clients.Group(roomId)
+                .SendAsync("ReceiveRoomMessage", roomId, userName, message.Trim());
+        }
+
+        // Leaves the SignalR group for a room; membership in DB remains,
+        // so the user will auto-rejoin on next visit/reconnect if you choose.
+        public async Task LeaveRoom(string roomId)
+        {
+            if (string.IsNullOrWhiteSpace(roomId)) return;
+
+            await Groups.RemoveFromGroupAsync(Context.ConnectionId, roomId);
+
+            await Clients.Group(roomId)
+                .SendAsync("SystemNotice", roomId, "Someone left the room");
         }
     }
 }

--- a/DndChat/Migrations/20251013111040_AddPrivateChatCore.Designer.cs
+++ b/DndChat/Migrations/20251013111040_AddPrivateChatCore.Designer.cs
@@ -4,6 +4,7 @@ using DndChat.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace DndChat.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20251013111040_AddPrivateChatCore")]
+    partial class AddPrivateChatCore
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/DndChat/Migrations/20251013111040_AddPrivateChatCore.cs
+++ b/DndChat/Migrations/20251013111040_AddPrivateChatCore.cs
@@ -1,0 +1,102 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DndChat.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPrivateChatCore : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ChatRooms",
+                columns: table => new
+                {
+                    Id = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    JoinCode = table.Column<string>(type: "nvarchar(64)", maxLength: 64, nullable: false),
+                    OwnerUserId = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    ChatName = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    CreatedUtc = table.Column<DateTime>(type: "datetime2", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ChatRooms", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "ChatMemberships",
+                columns: table => new
+                {
+                    Id = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    ChatRoomId = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    UserId = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    JoinedUtc = table.Column<DateTime>(type: "datetime2", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ChatMemberships", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_ChatMemberships_ChatRooms_ChatRoomId",
+                        column: x => x.ChatRoomId,
+                        principalTable: "ChatRooms",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "ChatMessages",
+                columns: table => new
+                {
+                    Id = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    ChatRoomId = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    UserId = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    UserName = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    MessageText = table.Column<string>(type: "nvarchar(2000)", maxLength: 2000, nullable: false),
+                    SentUtc = table.Column<DateTime>(type: "datetime2", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ChatMessages", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_ChatMessages_ChatRooms_ChatRoomId",
+                        column: x => x.ChatRoomId,
+                        principalTable: "ChatRooms",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ChatMemberships_ChatRoomId_UserId",
+                table: "ChatMemberships",
+                columns: new[] { "ChatRoomId", "UserId" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ChatMessages_ChatRoomId",
+                table: "ChatMessages",
+                column: "ChatRoomId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ChatRooms_JoinCode",
+                table: "ChatRooms",
+                column: "JoinCode",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ChatMemberships");
+
+            migrationBuilder.DropTable(
+                name: "ChatMessages");
+
+            migrationBuilder.DropTable(
+                name: "ChatRooms");
+        }
+    }
+}

--- a/DndChat/Models/ChatMembership.cs
+++ b/DndChat/Models/ChatMembership.cs
@@ -1,0 +1,12 @@
+﻿namespace DndChat.Models
+{
+    public class ChatMembership
+    {
+        public string Id { get; set; } = Guid.NewGuid().ToString();
+        public string ChatRoomId { get; set; } = default!;
+        public string UserId { get; set; } = default!;
+        public DateTime JoinedUtc { get; set; } = DateTime.UtcNow;
+        public ChatRoom ChatRoom { get; set; } = default!;
+        
+    }
+}

--- a/DndChat/Models/ChatMessage.cs
+++ b/DndChat/Models/ChatMessage.cs
@@ -1,0 +1,13 @@
+﻿namespace DndChat.Models
+{
+    public class ChatMessage
+    {
+        public string Id { get; set; } = Guid.NewGuid().ToString();
+        public string ChatRoomId { get; set; } = default!;
+        public string UserId { get; set; } = default!;
+        public string UserName { get; set; } = default!;
+        public string MessageText { get; set; } = default!;
+        public DateTime SentUtc { get; set; } = DateTime.UtcNow;
+        public ChatRoom ChatRoom { get; set; } = default!;
+    }
+}

--- a/DndChat/Models/ChatRoom.cs
+++ b/DndChat/Models/ChatRoom.cs
@@ -1,0 +1,14 @@
+﻿namespace DndChat.Models
+{
+    public class ChatRoom
+    {
+        public string Id { get; set; } = Guid.NewGuid().ToString();
+        public string JoinCode { get; set; } = default!;
+        public string OwnerUserId { get; set; } = default!;
+        public string? ChatName { get; set; }
+        public DateTime CreatedUtc { get; set; } = DateTime.UtcNow;
+
+        public ICollection<ChatMembership> Members { get; set; } = new List<ChatMembership>();
+        public ICollection<ChatMessage> Messages { get; set; } = new List<ChatMessage>();
+    }
+}

--- a/DndChat/Services/ChatRoomService.cs
+++ b/DndChat/Services/ChatRoomService.cs
@@ -1,0 +1,210 @@
+﻿using DndChat.Data;
+using DndChat.Models;
+using Microsoft.EntityFrameworkCore;
+using DndChat.ViewModels;
+
+namespace DndChat.Services
+{
+    // Provides room creation/lookup, membership, and message persistence for the chat hub.
+    public class ChatRoomService : IChatRoomService
+    {
+        private readonly ApplicationDbContext _dbContext;
+        public ChatRoomService(ApplicationDbContext dbContext) => _dbContext = dbContext;
+
+        // Creates a private room using a canonical join code (lowercase, no dashes),
+        // saves the creator as a member, and returns both the room id and the code to share.
+        public async Task<(string roomId, string joinCode)> CreatePrivateAsync(string ownerUserId, string? name = null)
+        {
+            var roomId = Guid.NewGuid().ToString("N"); // canonical form
+            var newRoom = new ChatRoom
+            {
+                Id = roomId,                  // set the Id explicitly (overrides property initializer)
+                JoinCode = roomId,            // store the same canonical value as the join code
+                OwnerUserId = ownerUserId,
+                ChatName = name
+            };
+
+            _dbContext.ChatRooms.Add(newRoom);
+            _dbContext.ChatMemberships.Add(new ChatMembership { ChatRoomId = roomId, UserId = ownerUserId });
+            await _dbContext.SaveChangesAsync();
+            return (roomId, roomId);         // MVP: code == roomId
+        }
+
+        // Looks up a room from what the user typed. We normalize the input so that
+        // UPPER/lower case and optional dashes still match the stored canonical code.
+        public async Task<string?> ResolveByJoinCodeAsync(string joinCode)
+        {
+            var normalized = (joinCode ?? string.Empty)
+                .Trim()
+                .Replace("-", "")
+                .ToLowerInvariant();
+
+            return await _dbContext.ChatRooms
+                .Where(room => room.JoinCode == normalized)
+                .Select(room => room.Id)
+                .FirstOrDefaultAsync();
+        }
+
+        // Returns true if the user is already in this room (enforced by unique index too).
+        public Task<bool> IsMemberAsync(string userId, string roomId) =>
+            _dbContext.ChatMemberships.AnyAsync(m => m.ChatRoomId == roomId && m.UserId == userId);
+
+        // Adds the user to the room if not already present.
+        public async Task AddMemberAsync(string userId, string roomId)
+        {
+            if (!await IsMemberAsync(userId, roomId))
+            {
+                _dbContext.ChatMemberships.Add(new ChatMembership { ChatRoomId = roomId, UserId = userId });
+                await _dbContext.SaveChangesAsync();
+            }
+        }
+
+        // Lists all room ids the user belongs to (used on connect to rejoin SignalR groups).
+        public async Task<List<string>> RoomsForUserAsync(string userId) =>
+            await _dbContext.ChatMemberships
+                .Where(m => m.UserId == userId)
+                .Select(m => m.ChatRoomId)
+                .ToListAsync();
+
+        // Persists a message for room history.
+        public async Task SaveMessageAsync(string roomId, string userId, string userName, string text)
+        {
+            var message = new ChatMessage
+            {
+                ChatRoomId = roomId,
+                UserId = userId,
+                UserName = userName,
+                MessageText = text.Trim()
+            };
+            _dbContext.ChatMessages.Add(message);
+            await _dbContext.SaveChangesAsync();
+        }
+
+        // Gets the most recent N messages, ordered oldest→newest for easy rendering.
+        public async Task<List<(string UserName, string Text, DateTime SentUtc)>> LastMessagesAsync(string roomId, int take = 50)
+        {
+            return await _dbContext.ChatMessages
+                .Where(m => m.ChatRoomId == roomId)
+                .OrderByDescending(m => m.SentUtc)
+                .Take(take)
+                .OrderBy(m => m.SentUtc)
+                .Select(m => new ValueTuple<string, string, DateTime>(m.UserName, m.MessageText, m.SentUtc))
+                .ToListAsync();
+        }
+
+        // Returns minimal header data for the room page.
+        public async Task<RoomHeaderDto?> GetRoomHeaderAsync(string roomId)
+        {
+            return await _dbContext.ChatRooms
+                .AsNoTracking()
+                .Where(r => r.Id == roomId)
+                .Select(r => new RoomHeaderDto
+                {
+                    Id = r.Id,
+                    Name = r.ChatName ?? "Private Room",
+                    JoinCode = r.JoinCode
+                })
+                .SingleOrDefaultAsync();
+        }
+
+        // Secure: only return if the user belongs to the room (global is always allowed).
+        public async Task<RoomHeaderDto?> GetRoomHeaderForUserAsync(string userId, string roomId)
+        {
+            // Block access if not a member (global always allowed)
+            if (!string.Equals(roomId, "global", StringComparison.OrdinalIgnoreCase))
+            {
+                var isMember = await _dbContext.ChatMemberships
+                    .AsNoTracking()
+                    .AnyAsync(m => m.ChatRoomId == roomId && m.UserId == userId);
+                if (!isMember) return null;
+            }
+
+            // Project to header and compute IsOwner
+            return await _dbContext.ChatRooms
+                .AsNoTracking()
+                .Where(r => r.Id == roomId)
+                .Select(r => new RoomHeaderDto
+                {
+                    Id = r.Id,
+                    Name = r.ChatName ?? "Private Room",
+                    JoinCode = r.JoinCode,
+                    OwnerUserId = r.OwnerUserId,
+                    IsOwner = (r.OwnerUserId == userId) // <-- compute here
+                })
+                .SingleOrDefaultAsync();
+        }
+
+        // History projected to DTOs so the client gets a clean shape.
+        public async Task<List<ChatMessageDto>> LastMessagesDtoAsync(string roomId, int take = 50)
+        {
+            return await _dbContext.ChatMessages
+                .AsNoTracking()
+                .Where(m => m.ChatRoomId == roomId)
+                .OrderByDescending(m => m.SentUtc)
+                .Take(take)
+                .OrderBy(m => m.SentUtc) // oldest → newest for rendering
+                .Select(m => new ChatMessageDto
+                {
+                    UserName = m.UserName,
+                    Text = m.MessageText,
+                    SentUtc = m.SentUtc
+                })
+                .ToListAsync();
+        }
+        // Returns rooms (except the "global" row) that the user belongs to.
+        public async Task<IReadOnlyList<UserRoomDto>> RoomsForUserListAsync(string userId)
+        {
+            return await _dbContext.ChatMemberships
+                .AsNoTracking()
+                .Where(m => m.UserId == userId && m.ChatRoomId != "global")
+                .Select(m => new UserRoomDto
+                {
+                    Id = m.ChatRoomId,
+                    Name = m.ChatRoom.ChatName ?? "Private Room",
+                    JoinCode = m.ChatRoom.JoinCode,
+                    IsOwner = m.ChatRoom.OwnerUserId == userId
+                })
+                .OrderBy(r => r.Name)
+                .ToListAsync();
+        }
+
+        // Removes a single membership (does not delete messages or the room itself).
+        public async Task RemoveMemberAsync(string userId, string roomId)
+        {
+            var membership = await _dbContext.ChatMemberships
+                .Where(m => m.UserId == userId && m.ChatRoomId == roomId)
+                .FirstOrDefaultAsync();
+
+            if (membership is null) return;
+
+            _dbContext.ChatMemberships.Remove(membership);
+            await _dbContext.SaveChangesAsync();
+        }
+
+        public async Task<bool> IsOwnerAsync(string userId, string roomId)
+        {
+            return await _dbContext.ChatRooms
+                .AsNoTracking()
+                .AnyAsync(r => r.Id == roomId && r.OwnerUserId == userId);
+        }
+
+        public async Task<bool> DeleteRoomAsync(string ownerUserId, string roomId)
+        {
+            // Never allow deleting the seeded global room
+            if (string.Equals(roomId, "global", StringComparison.OrdinalIgnoreCase))
+                return false;
+
+            // Make sure the caller owns this room
+            var room = await _dbContext.ChatRooms
+                .FirstOrDefaultAsync(r => r.Id == roomId && r.OwnerUserId == ownerUserId);
+
+            if (room is null) return false;
+
+            // Cascade deletes will remove memberships + messages (you already configured Cascade)
+            _dbContext.ChatRooms.Remove(room);
+            await _dbContext.SaveChangesAsync();
+            return true;
+        }
+    }
+}
+

--- a/DndChat/Services/IChatRoomService.cs
+++ b/DndChat/Services/IChatRoomService.cs
@@ -1,0 +1,33 @@
+﻿using DndChat.ViewModels;
+
+namespace DndChat.Services
+{
+    public interface IChatRoomService
+    {
+        Task<(string roomId, string joinCode)> CreatePrivateAsync(string ownerUserId, string? name = null);
+        Task<string?> ResolveByJoinCodeAsync(string joinCode);
+        Task<bool> IsMemberAsync(string userId, string roomId);
+        Task AddMemberAsync(string userId, string roomId);
+        Task<List<string>> RoomsForUserAsync(string userId);
+        Task SaveMessageAsync(string roomId, string userId, string userName, string text);
+        Task<List<(string UserName, string Text, DateTime SentUtc)>> LastMessagesAsync(string roomId, int take = 50);
+
+        // NEW: read-only room header for the controller (id + name + code)
+        Task<RoomHeaderDto?> GetRoomHeaderAsync(string roomId);
+
+        Task<RoomHeaderDto?> GetRoomHeaderForUserAsync(string userId, string roomId);
+
+        // Returns message history already projected to a simple DTO shape that the JS expects.
+        // Using DTOs avoids tuple serialization quirks and keeps the payload stable.
+        Task<List<ChatMessageDto>> LastMessagesDtoAsync(string roomId, int take = 50);
+
+        // Lists all private rooms this user belongs to (excluding "global")
+        Task<IReadOnlyList<UserRoomDto>> RoomsForUserListAsync(string userId);
+
+        // Optional: allow a user to leave a room (keeps the room for others)
+        Task RemoveMemberAsync(string userId, string roomId);
+
+        Task<bool> DeleteRoomAsync(string ownerUserId, string roomId);
+        Task<bool> IsOwnerAsync(string userId, string roomId);
+    }
+}

--- a/DndChat/ViewModels/ChatMessageDto.cs
+++ b/DndChat/ViewModels/ChatMessageDto.cs
@@ -1,0 +1,10 @@
+﻿namespace DndChat.ViewModels
+{
+    // Small data object we send to the client for chat history/live messages.
+    public class ChatMessageDto
+    {
+        public string UserName { get; set; } = default!;
+        public string Text { get; set; } = default!;
+        public DateTime SentUtc { get; set; }
+    }
+}

--- a/DndChat/ViewModels/RoomHeaderDto.cs
+++ b/DndChat/ViewModels/RoomHeaderDto.cs
@@ -1,0 +1,13 @@
+﻿namespace DndChat.ViewModels
+{
+    // Small, read-only-ish shape for the room header (id, display name, join code).
+    public class RoomHeaderDto
+    {
+        public string Id { get; set; } = default!;
+        public string Name { get; set; } = default!;
+        public string JoinCode { get; set; } = default!;
+        public string OwnerUserId { get; set; } = default!;
+        public bool IsOwner { get; set; }
+
+    }
+}

--- a/DndChat/ViewModels/UserRoomDto.cs
+++ b/DndChat/ViewModels/UserRoomDto.cs
@@ -1,0 +1,10 @@
+﻿namespace DndChat.ViewModels
+{
+    public class UserRoomDto
+    {
+        public string Id { get; set; } = default!;
+        public string Name { get; set; } = default!;
+        public string JoinCode { get; set; } = default!;
+        public bool IsOwner { get; set; }
+    }
+}

--- a/DndChat/Views/Chat/Index.cshtml
+++ b/DndChat/Views/Chat/Index.cshtml
@@ -1,6 +1,7 @@
 ﻿@* Views/Chat/Index.cshtml *@
 @using Microsoft.AspNetCore.Authorization
 @{
+    ViewData["Title"] = "Global chat";
     // Is the current HTTP user authenticated?
     var isAuthed = User?.Identity?.IsAuthenticated ?? false;
 
@@ -26,6 +27,12 @@
         </p>
     }
 
+    <div class="my-3">
+        <a class="btn btn-outline-primary btn-sm" asp-controller="Rooms" asp-action="Index">
+            Go to private rooms
+        </a>
+    </div>
+
     @* MAIN CHAT AREA
        - We only show this when the user is authenticated.
        - chat.js will read data-joined and data-username from #root and
@@ -49,7 +56,7 @@
                         type="button"
                         class="btn btn-success"
                         @(isAuthed ? "" : "disabled")>
-                    Chat
+                    Send
                 </button>
             </div>
         </div>

--- a/DndChat/Views/Rooms/Index.cshtml
+++ b/DndChat/Views/Rooms/Index.cshtml
@@ -1,0 +1,108 @@
+﻿@using System.Linq
+@using DndChat.ViewModels
+@model IEnumerable<UserRoomDto>
+
+@{
+    ViewData["Title"] = "Private rooms";
+    var joinError = TempData["JoinError"] as string;
+}
+
+<div class="container py-4">
+    <h1 class="mb-4">Private rooms</h1>
+
+    @if (!string.IsNullOrWhiteSpace(joinError))
+    {
+        <div class="alert alert-warning">@joinError</div>
+    }
+
+    <div class="row g-4">
+        <div class="col-md-6">
+            <div class="card h-100">
+                <div class="card-header">Join a room</div>
+                <div class="card-body">
+                    <p>Enter the join code you received.</p>
+                    <form asp-action="Join" method="post" class="row gy-2">
+                        @Html.AntiForgeryToken()
+                        <div class="col-12">
+                            <input name="joinCode" class="form-control" placeholder="Enter join code (e.g. a1b2c3d4)" />
+                        </div>
+                        <div class="col-12">
+                            <button class="btn btn-primary" type="submit">Join room</button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+
+        <div class="col-md-6">
+            <div class="card h-100">
+                <div class="card-header">Create a room</div>
+                <div class="card-body">
+                    <p>Create your own private room and share the code.</p>
+                    <form asp-action="Create" method="post" class="row gy-2">
+                        @Html.AntiForgeryToken()
+                        <div class="col-12">
+                            <input name="roomName" class="form-control" placeholder="Optional room name" />
+                        </div>
+                        <div class="col-12">
+                            <button class="btn btn-success" type="submit">Create room</button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    @if (Model != null && Model.Any())
+    {
+        <div class="mt-4">
+            <div class="card">
+                <div class="card-header">Your rooms</div>
+                <div class="list-group list-group-flush">
+                    @foreach (var r in Model)
+                    {
+                        <div class="list-group-item d-flex align-items-center justify-content-between">
+                            <div>
+                                <a asp-action="Room" asp-route-id="@r.Id" class="fw-semibold me-2">@r.Name</a>
+                                @if (r.IsOwner)
+                                {
+                                    <span class="badge bg-secondary">Owner</span>
+                                }
+                                <div class="small text-muted mt-1">
+                                    Code: <code>@r.JoinCode</code>
+                                </div>
+                            </div>
+                            <div class="d-flex gap-2">
+                                <button type="button" class="btn btn-outline-secondary btn-sm copy-btn" data-code="@r.JoinCode">Copy code</button>
+                                <form asp-action="Leave" method="post" class="d-inline">
+                                    @Html.AntiForgeryToken()
+                                    <input type="hidden" name="id" value="@r.Id" />
+                                    <button type="submit" class="btn btn-outline-danger btn-sm">Leave</button>
+                                </form>
+                            </div>
+                        </div>
+                    }
+                </div>
+            </div>
+        </div>
+    }
+
+    <div class="mt-3">
+        <a asp-controller="Chat" asp-action="Index" class="link-secondary">&larr; Back to Global chat</a>
+    </div>
+</div>
+
+@section Scripts {
+    <script>
+        // Simple copy buttons for join codes
+        document.querySelectorAll('.copy-btn').forEach(btn => {
+            btn.addEventListener('click', async () => {
+                try {
+                    await navigator.clipboard.writeText(btn.dataset.code);
+                    btn.textContent = 'Copied!';
+                    setTimeout(() => btn.textContent = 'Copy code', 1200);
+                } catch { /* ignore */ }
+            });
+        });
+    </script>
+}

--- a/DndChat/Views/Rooms/Room.cshtml
+++ b/DndChat/Views/Rooms/Room.cshtml
@@ -1,0 +1,60 @@
+﻿@{
+    // WHY: Controller put these into ViewData; we render them as data-* attributes for JS.
+    var roomId = (string)ViewData["RoomId"]!;
+    var roomName = (string)ViewData["RoomName"]!;
+    var joinCode = (string)ViewData["JoinCode"]!;
+    var isOwner = (bool)(ViewData["IsOwner"] ?? false);
+}
+
+<div class="container py-4"
+     id="roomRoot"
+     data-room-id="@roomId"
+     data-room-name="@roomName"
+     data-join-code="@joinCode">
+
+    <div class="d-flex align-items-center justify-content-between mb-3">
+        <h1 class="h3 mb-0">@roomName</h1>
+
+        <div class="d-flex align-items-center gap-2">
+            <span class="badge bg-secondary" id="joinCodeBadge">@joinCode</span>
+            <button class="btn btn-outline-secondary btn-sm" id="copyJoinCodeBtn" type="button">Copy code</button>
+            <a asp-controller="Rooms" asp-action="Index" class="btn btn-link btn-sm">All rooms</a>
+            <button class="btn btn-outline-danger btn-sm" id="leaveBtn" type="button">Leave</button>
+            @if (isOwner)
+            {
+                <form asp-action="Delete" method="post" class="d-inline">
+                    @Html.AntiForgeryToken()
+                    <input type="hidden" name="id" value="@ViewData["RoomId"]" />
+                    <button class="btn btn-outline-danger btn-sm">Delete room</button>
+                </form>
+            }
+        </div>
+    </div>
+
+    <div class="card">
+        <div class="card-header">Room messages</div>
+
+        @* Scrollable message list *@
+        <ul id="messagesList" class="list-group list-group-flush" style="max-height: 50vh; overflow:auto;"></ul>
+
+        <div class="card-body">
+            <div class="input-group">
+                <input id="messageInput" class="form-control" placeholder="Type a message" autocomplete="off" />
+                <button id="sendBtn" type="button" class="btn btn-success">Send</button>
+            </div>
+        </div>
+    </div>
+
+    <div id="status" class="mt-3"></div>
+</div>
+
+@section Scripts {
+    @* Validation scripts if you use them elsewhere *@
+    <partial name="_ValidationScriptsPartial" />
+    @* SignalR client library *@
+    <script src="~/lib/microsoft/signalr/dist/browser/signalr.js" asp-append-version="true"></script>
+    @* DOMPurify (only if not already included in your layout). Safe to keep here. *@
+    <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.8/dist/purify.min.js" integrity="sha256-lfa0k5n2i8lGfRrjzQ6g8Yq3aFJ1w2Q1fA2/0sEe5NQ=" crossorigin="anonymous"></script>
+    @* Room-specific JS *@
+    <script src="~/js/chat-room.js" asp-append-version="true"></script>
+}

--- a/DndChat/Views/Shared/_Layout.cshtml
+++ b/DndChat/Views/Shared/_Layout.cshtml
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>@ViewData["Title"] - DndChat</title>
-    <script type="importmap"></script>
+
     <link rel="stylesheet" href="~/lib/bootstrap/dist/css/bootstrap.min.css" />
     <link rel="stylesheet" href="~/css/site.css" asp-append-version="true" />
     <link rel="stylesheet" href="~/DndChat.styles.css" asp-append-version="true" />
@@ -19,10 +19,13 @@
                         aria-controls="mainNav" aria-expanded="false" aria-label="Toggle navigation">
                     <span class="navbar-toggler-icon"></span>
                 </button>
-                <div class="collapse navbar-collapse">
+                <div class="collapse navbar-collapse" id="mainNav">
                     <ul class="navbar-nav me-auto">
                         <li class="nav-item">
-                            <a class="nav-link" asp-controller="Chat" asp-action="Index">Chat</a>
+                            <a class="nav-link" asp-controller="Chat" asp-action="Index">Global chat</a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link" asp-controller="Rooms" asp-action="Index">Private rooms</a>
                         </li>
                     </ul>
 

--- a/DndChat/wwwroot/js/chat-room.js
+++ b/DndChat/wwwroot/js/chat-room.js
@@ -1,0 +1,183 @@
+﻿// Immediately-invoked module so variables don't leak to window.*
+(() => {
+    // Used only when writing innerHTML (status banners). Safe to omit if you already include it globally.
+    const sanitizeForInnerHTML = (value) => DOMPurify.sanitize(String(value));
+
+    // === Grab page data the controller put into data-* attributes ===
+    // WHY: the controller passes room id/name/code to the view; JS reads them here.
+    const root = document.getElementById('roomRoot');
+    const roomId = root?.dataset.roomId || '';
+    const roomName = root?.dataset.roomName || 'Private Room';
+    const joinCode = root?.dataset.joinCode || '';
+
+    // === Cache UI elements we update frequently ===
+    // WHY: avoids repeated DOM lookups in handlers.
+    const messages = document.getElementById('messagesList');
+    const input = document.getElementById('messageInput');
+    const sendBtn = document.getElementById('sendBtn');
+    const status = document.getElementById('status');
+    const copyBtn = document.getElementById('copyJoinCodeBtn');
+    const leaveBtn = document.getElementById('leaveBtn');
+
+    // === Disable input until SignalR is connected ===
+    input.disabled = true;
+    sendBtn.disabled = true;
+
+    // === Helper to mint a short-lived JWT (falls back to cookie if not available) ===
+    // WHY: matches your global page; enables WebSocket auth when needed.
+    async function getJwt() {
+        try {
+            const res = await fetch('/api/auth/token', {
+                method: 'POST',
+                headers: { 'X-Requested-With': 'XMLHttpRequest' }
+            });
+            if (!res.ok) throw new Error('HTTP ' + res.status);
+            const { accessToken } = await res.json();
+            return accessToken;
+        } catch (err) {
+            console.warn('JWT fetch failed, falling back to cookie auth', err);
+            return null; // cookie auth still works
+        }
+    }
+
+    // === Build and start the SignalR connection, then join THIS room ===
+    (async () => {
+        // Short-circuit: we need a room id to proceed.
+        if (!roomId) {
+            status.innerHTML = `<div class="alert alert-danger">Missing room id.</div>`;
+            return;
+        }
+
+        const token = await getJwt();
+
+        // Build the connection with/without JWT.
+        const builder = new signalR.HubConnectionBuilder();
+        const configured = token
+            ? builder.withUrl('/chathub', { accessTokenFactory: () => token })
+            : builder.withUrl('/chathub');
+
+        // IMPORTANT: build from `configured`, not `builder`, so we keep URL+token.
+        const conn = configured.withAutomaticReconnect().build();
+
+        // === Handlers the hub will call back ===
+
+        // WHY: load last N messages as soon as we join the room so the view isn't empty.
+        conn.on('LoadHistory', (rid, items) => {
+            if (rid !== roomId) return;
+            // Optional: clear any stale lines before rendering history.
+            // messages.innerHTML = '';
+            for (const item of items) {
+                const li = document.createElement('li');
+                li.className = 'list-group-item';
+                li.textContent = `${item.UserName}: ${item.Text}`;
+                messages.appendChild(li);
+            }
+            messages.scrollTop = messages.scrollHeight;
+        });
+
+        // WHY: render live messages for this room only.
+        conn.on('ReceiveRoomMessage', (rid, userName, text) => {
+            if (rid !== roomId) return;
+            const li = document.createElement('li');
+            li.className = 'list-group-item';
+            li.textContent = `${userName}: ${text}`;
+            messages.appendChild(li);
+            messages.scrollTop = messages.scrollHeight;
+        });
+
+        // WHY: show system activity lines (joined/left/created) for this room only.
+        conn.on('SystemNotice', (rid, text) => {
+            if (rid !== roomId) return;
+            const li = document.createElement('li');
+            li.className = 'list-group-item text-muted fst-italic';
+            li.textContent = text;
+            messages.appendChild(li);
+            messages.scrollTop = messages.scrollHeight;
+        });
+        conn.on('RoomDeleted', (rid, reason) => {
+            if (rid !== roomId) return;
+
+            // safer: build the alert node and set textContent
+            const alert = document.createElement('div');
+            alert.className = 'alert alert-warning';
+            alert.textContent = reason;
+            status.replaceChildren(alert);
+
+            input.disabled = true;
+            sendBtn.disabled = true;
+
+            setTimeout(() => { window.location.href = '/Rooms'; }, 1200);
+        });
+
+        // === Connection status UI ===
+        conn.onreconnecting(() => {
+            status.innerHTML = `<div class="alert alert-warning py-2">Reconnecting…</div>`;
+            sendBtn.disabled = true; input.disabled = true;
+        });
+
+        conn.onreconnected(async () => {
+            status.innerHTML = `<div class="alert alert-success py-2">Reconnected</div>`;
+            sendBtn.disabled = false; input.disabled = false;
+
+            // IMPORTANT: re-join THIS room after reconnect so we keep receiving events.
+            await conn.invoke('JoinByCode', roomId);
+        });
+
+        conn.onclose(err => {
+            const safeErr = err ? `: ${sanitizeForInnerHTML(err)}` : '';
+            status.innerHTML = `<div class="alert alert-danger py-2">Connection closed${safeErr}</div>`;
+            sendBtn.disabled = true; input.disabled = true;
+        });
+
+        // === Start and join THIS room ===
+        try {
+            await conn.start();
+            input.disabled = false; sendBtn.disabled = false;
+            status.innerHTML = `<div class="alert alert-success py-2">Connected to <strong>${sanitizeForInnerHTML(roomName)}</strong></div>`;
+
+            // Tell the hub to add this connection to the SignalR group for the room.
+            await conn.invoke('JoinByCode', roomId);
+        } catch (err) {
+            status.innerHTML = `<div class="alert alert-danger">Connect failed: ${sanitizeForInnerHTML(err)}</div>`;
+            console.error('SignalR connect error', err);
+            return;
+        }
+
+        // === Send message button ===
+        sendBtn.addEventListener('click', async () => {
+            const text = input.value.trim();
+            if (!text) return;
+            input.value = '';
+            try {
+                await conn.invoke('SendRoomMessage', roomId, text);
+            } catch (err) {
+                status.innerHTML = `<div class="alert alert-warning">Send failed: ${sanitizeForInnerHTML(err)}</div>`;
+                console.error('Send failed', err);
+            }
+        });
+
+        // === Enter to send ===
+        input.addEventListener('keydown', e => {
+            if (e.key === 'Enter') { sendBtn.click(); e.preventDefault(); }
+        });
+
+        // === Copy join code to clipboard ===
+        copyBtn?.addEventListener('click', async () => {
+            try {
+                await navigator.clipboard.writeText(joinCode);
+                status.innerHTML = `<div class="alert alert-info py-2">Join code copied</div>`;
+            } catch {
+                status.innerHTML = `<div class="alert alert-warning py-2">Couldn’t copy. Select and copy manually.</div>`;
+            }
+        });
+
+        // === Leave button: tell the hub, then navigate back to /Rooms ===
+        leaveBtn?.addEventListener('click', async () => {
+            leaveBtn.disabled = true;
+            try {
+                await conn.invoke('LeaveRoom', roomId);
+            } catch { /* ignore */ }
+            window.location.href = '/Rooms';
+        });
+    })();
+})();

--- a/DndChat/wwwroot/js/chat.js
+++ b/DndChat/wwwroot/js/chat.js
@@ -1,137 +1,207 @@
-﻿// Immediately-invoked module to avoid leaking variables to global scope
+﻿// Immediately-invoked module so our variables don’t leak into window.*
 (() => {
-    // XSS protection but only needed when we use innerHTML.
-    // DOMPurify.sanitize(...) removes dangerous tags/attributes (e.g. <script>, onerror=, javascript: URLs)
-    // so we can safely insert user-controlled text into an HTML template.
-    const sanitizeForInnerHTML = (value) => DOMPurify.sanitize(String(value));
-    // Grab auth + UI state that Razor put on the page
+  // DOMPurify is used only when we set innerHTML (status banners).
+  const sanitizeForInnerHTML = (value) => DOMPurify.sanitize(String(value));
+
+    // Pull auth + UI state that Razor wrote into #root.
     const root = document.getElementById('root');
     const joined = (root?.dataset.joined || '').toLowerCase() === 'true';
     const username = root?.dataset.username || '';
 
-    // Cache DOM elements we’ll use
+    // Cache the main UI elements we update frequently.
     const messages = document.getElementById('messagesList');
     const input = document.getElementById('messageInput');
     const sendBtn = document.getElementById('sendBtn');
     const status = document.getElementById('status');
 
-    // Disable input until SignalR has connected
+    // Cache the new private-room toolbar elements.
+    const createPrivateBtn = document.getElementById('createPrivateBtn');
+    const joinPrivateBtn   = document.getElementById('joinPrivateBtn');
+    const roomIdInput      = document.getElementById('roomIdInput');
+    const roomBadge        = document.getElementById('roomBadge');
+
+    // Tracks which private room is active. When null, you’re in Global.
+    let currentRoomId = null;
+
+    // Lock inputs until the SignalR connection is up.
     input.disabled = true;
     sendBtn.disabled = true;
 
-    // If the user isn’t authenticated, don’t start SignalR
+    // If the user isn’t authenticated, don’t even try to connect.
     if (!joined || username.length < 3) {
         console.log('Not authenticated; waiting.');
-        return;
-    }
+    return;
+  }
 
-    // Ask the server (cookie-protected) to mint a short-lived JWT we can use for SignalR/API
+    // Cookie-protected call that mints a short-lived JWT for SignalR.
     async function getJwt() {
-        try {
-            const res = await fetch('/api/auth/token', {
-                method: 'POST',
-                headers: { 'X-Requested-With': 'XMLHttpRequest' }
-            });
-            if (!res.ok) throw new Error('HTTP ' + res.status);
-            const { accessToken } = await res.json();
-            return accessToken;
-        } catch (err) {
-            console.warn('JWT fetch failed, falling back to cookie auth', err);
-            return null;
-        }
+    try {
+      const res = await fetch('/api/auth/token', {
+        method: 'POST',
+        headers: {'X-Requested-With': 'XMLHttpRequest' }
+      });
+    if (!res.ok) throw new Error('HTTP ' + res.status);
+    const {accessToken} = await res.json();
+    return accessToken;
+    } catch (err) {
+        console.warn('JWT fetch failed, falling back to cookie auth', err);
+        return null; // cookie auth will still work
     }
+  }
 
-    // Bootstrap SignalR using JWT if available; otherwise fall back to cookie auth
-    (async () => {
-        const token = await getJwt();
+  // Bootstraps SignalR. If we have a JWT, pass it; otherwise use cookies.
+  (async () => {
+    const token = await getJwt();
 
-        // TEMP: debug — show the raw token (remove in production)
-        console.log('JWT:', token);
+    // Build the connection with the right URL/options.
+    const builder = new signalR.HubConnectionBuilder();
+    const configured = token
+    ? builder.withUrl('/chathub', {accessTokenFactory: () => token })
+    : builder.withUrl('/chathub');
 
-        // Build the SignalR connection, passing the JWT via accessTokenFactory when we have one
-        const builder = new signalR.HubConnectionBuilder();
-        const configured = token
-            ? builder.withUrl('/chathub', { accessTokenFactory: () => token })
-            : builder.withUrl('/chathub');
+    // IMPORTANT: build from `configured` so we keep the URL + token.
+    const conn = configured.withAutomaticReconnect().build();
 
-        // Turn on automatic reconnects and create the connection instance
-        const conn = builder.withAutomaticReconnect().build();
+    // Render normal global chat lines.
+    conn.on('ReceiveMessage', (user, text) => {
+      const li = document.createElement('li');
+    li.className = 'list-group-item';
+    li.textContent = `${user}: ${text}`;
+    messages.appendChild(li);
+    messages.scrollTop = messages.scrollHeight;
+    });
 
-        conn.on('ReceiveMessage', (user, text) => {
-            const li = document.createElement('li');
-            li.className = 'list-group-item';
-            li.textContent = `${user}: ${text}`;
-            messages.appendChild(li);
-            messages.scrollTop = messages.scrollHeight;
+    // Render system notices (used by both global and private rooms).
+    conn.on('SystemNotice', (roomId, text) => {
+      const li = document.createElement('li');
+    li.className = 'list-group-item text-muted fst-italic';
+    li.textContent = text;
+    messages.appendChild(li);
+    messages.scrollTop = messages.scrollHeight;
+    });
+
+    // Render messages for the currently active private room only.
+    conn.on('ReceiveRoomMessage', (roomId, userName, text) => {
+      if (currentRoomId && roomId === currentRoomId) {
+        const li = document.createElement('li');
+    li.className = 'list-group-item';
+    li.textContent = `${userName}: ${text}`;
+    messages.appendChild(li);
+    messages.scrollTop = messages.scrollHeight;
+      }
+    });
+
+    // Load recent history after joining a private room so it’s not empty.
+    conn.on('LoadHistory', (roomId, items) => {
+      // If you prefer a clean view per room, uncomment:
+      // messages.innerHTML = '';
+      for (const item of items) {
+        const li = document.createElement('li');
+    li.className = 'list-group-item';
+    li.textContent = `${item.UserName}: ${item.Text}`;
+    messages.appendChild(li);
+      }
+    messages.scrollTop = messages.scrollHeight;
+    });
+
+    // Connection status UI.
+    conn.onreconnecting(() => {
+        status.innerHTML = `<div class="alert alert-warning py-2">Reconnecting…</div>`;
+        sendBtn.disabled = true; input.disabled = true;
+    });
+
+    conn.onreconnected(async () => {
+        const safeUser = sanitizeForInnerHTML(username);
+        status.innerHTML = `<div class="alert alert-success py-2">Connected as <strong>${safeUser}</strong></div>`;
+        sendBtn.disabled = false; input.disabled = false;
+
+        // If you are currently in a private room, re-join that only.
+        // Otherwise, re-join the global group.
+        if (currentRoomId) {
+            await conn.invoke('JoinByCode', currentRoomId); // joinCode == roomId in MVP
+        } else {
+            await conn.invoke('JoinGlobal');
+        }
+    });
+
+    conn.onclose(err => {
+        const safeErr = err ? `: ${sanitizeForInnerHTML(err)}` : '';
+        status.innerHTML = `<div class="alert alert-danger py-2">Connection closed${safeErr}</div>`;
+        sendBtn.disabled = true; input.disabled = true;
         });
 
-        // When a message arrives, render it in the list
-        conn.on('SystemNotice', (roomId, text) => {
-            const li = document.createElement('li');
-            li.className = 'list-group-item text-muted fst-italic';
-            li.textContent = text; // safe (no HTML)
-            messages.appendChild(li);
-            messages.scrollTop = messages.scrollHeight;
-        });
-
-        // Show reconnecting/connected/closed status and lock inputs appropriately
-        conn.onreconnecting(() => {
-            // Static message so no sanitization needed
-            status.innerHTML = `<div class="alert alert-warning py-2">Reconnecting…</div>`;
-            sendBtn.disabled = true;
-            input.disabled = true;
-        });
-
-        conn.onreconnected(() => {
-            // DOMPurify: sanitize dynamic username before inserting via innerHTML
-            const safeUser = sanitizeForInnerHTML(username);
-            status.innerHTML = `<div class="alert alert-success py-2">Connected as <strong>${safeUser}</strong></div>`;
-            sendBtn.disabled = false;
-            input.disabled = false;
-        });
-
-        conn.onclose(err => {
-            // DOMPurify: err could be anything; sanitize before innerHTML
-            const safeErr = err ? `: ${sanitizeForInnerHTML(err)}` : '';
-            status.innerHTML = `<div class="alert alert-danger py-2">Connection closed${safeErr}</div>`;
-            sendBtn.disabled = true;
-            input.disabled = true;
-        });
-
-        // Start the connection, then enable inputs
+        // Start the connection and unlock inputs.
         try {
             await conn.start();
-            input.disabled = false;
-            sendBtn.disabled = false;
-
-            // DOMPurify: sanitize dynamic username before innerHTML
-            const safeUser = sanitizeForInnerHTML(username);
+        input.disabled = false; sendBtn.disabled = false;
+        const safeUser = sanitizeForInnerHTML(username);
             status.innerHTML = `<div class="alert alert-success py-2">Connected as <strong>${safeUser}</strong></div>`;
+
+            // Explicitly join the global SignalR group on initial connect
+            await conn.invoke('JoinGlobal');
+
         } catch (err) {
-            // DOMPurify: sanitize error text before innerHTML
             status.innerHTML = `<div class="alert alert-danger">Connection failed: ${sanitizeForInnerHTML(err)}</div>`;
-            console.error('SignalR connect error', err);
-            return;
+        console.error('SignalR connect error', err);
+        return;
         }
 
-        // Send a chat message to the hub
-        sendBtn.addEventListener('click', async () => {
-            const text = input.value.trim();
-            if (!text) return;
+      // Create a private room, join it, and show the code for sharing.
+      createPrivateBtn?.addEventListener('click', async () => {
+          try {
+              // Optional: leave global so this window only shows the private room stream
+              await conn.invoke('LeaveGlobal'); // NEW (optional)
 
-            input.value = '';
-            try {
-                await conn.invoke('SendMessage', text);
-            } catch (err) {
-                // DOMPurify: sanitize error text before innerHTML
-                status.innerHTML = `<div class="alert alert-warning">Send failed: ${sanitizeForInnerHTML(err)}</div>`;
-                console.error('Send failed', err);
-            }
-        });
+              const result = await conn.invoke('CreatePrivateRoom', null);
+              currentRoomId = result.roomId;       // joinCode == roomId in MVP
+              roomBadge.textContent = `Private room: ${currentRoomId}`;
+              roomIdInput.value = currentRoomId;
+              // messages.innerHTML = ''; // optional clear
+          } catch (err) {
+              status.innerHTML = `<div class="alert alert-warning">Create failed: ${sanitizeForInnerHTML(err)}</div>`;
+              console.error(err);
+          }
+      });
 
-        // Allow pressing Enter to send
-        input.addEventListener('keydown', e => {
-            if (e.key === 'Enter') { sendBtn.click(); e.preventDefault(); }
-        });
-    })();
+      // Join an existing private room by its code (which is the room id).
+      joinPrivateBtn?.addEventListener('click', async () => {
+          const code = roomIdInput.value.trim();
+          if (!code) return;
+          try {
+              // Optional: leave global to avoid mixed streams in this window
+              await conn.invoke('LeaveGlobal'); // NEW (optional)
+
+              await conn.invoke('JoinByCode', code);
+              currentRoomId = code;
+              roomBadge.textContent = `Private room: ${code}`;
+              // messages.innerHTML = ''; // optional clear
+          } catch (err) {
+              status.innerHTML = `<div class="alert alert-warning">Join failed: ${sanitizeForInnerHTML(err)}</div>`;
+              console.error(err);
+          }
+      });
+
+    // Route outgoing messages: to the active private room or to Global if none.
+    sendBtn.addEventListener('click', async () => {
+      const text = input.value.trim();
+    if (!text) return;
+
+    input.value = '';
+    try {
+        if (currentRoomId) {
+        await conn.invoke('SendRoomMessage', currentRoomId, text);
+        } else {
+        await conn.invoke('SendMessage', text);
+        }
+      } catch (err) {
+        status.innerHTML = `<div class="alert alert-warning">Send failed: ${sanitizeForInnerHTML(err)}</div>`;
+    console.error('Send failed', err);
+      }
+    });
+
+    // Allow Enter to send.
+    input.addEventListener('keydown', e => {
+      if (e.key === 'Enter') {sendBtn.click(); e.preventDefault(); }
+    });
+  })();
 })();


### PR DESCRIPTION
This pull request introduces private chat room functionality to the DndChat application, including support for creating, joining, leaving, and deleting rooms, as well as sending messages in both global and private chats. It adds new models, controllers, hub methods, and database schema changes to enable these features, with robust membership and message persistence.

**Private Chat Room Features:**

* Added `RoomsController` to handle room creation, joining by code, leaving, viewing, and deletion, with appropriate authorization and user feedback.
* Extended `ChatHub` to support SignalR group management for global and private rooms, including methods for joining/leaving rooms, sending messages, and broadcasting system notices.

**Database Schema and Persistence:**

* Updated `ApplicationDbContext` to include new entities (`ChatRoom`, `ChatMembership`, `ChatMessage`) and configured relationships, uniqueness constraints, and message length limits.
* Added migration `AddPrivateChatCore` to create tables for chat rooms, memberships, and messages, with appropriate indexes and foreign keys.
* Updated `ApplicationDbContextModelSnapshot` to reflect new entities, relationships, and constraints for chat rooms, memberships, and messages.